### PR TITLE
Fix ReferenceError in the AI error path (quota refund read try-scoped vars) + quiet CSP report-only noise

### DIFF
--- a/server.js
+++ b/server.js
@@ -2438,6 +2438,17 @@ const SERVER_REPORT_RESPONSE_SCHEMA = Object.freeze({
 
 // Browser compatibility endpoint. Provider/model selection remains server-owned.
 app.post('/api/gemini/generateContent', geminiLimiter, geminiConcurrency, requireSession, defaultJsonParser, async (req, res) => {
+  // Declared in the handler scope, not inside the try: the catch below reads them
+  // to refund the quota reservation, and a catch block is a sibling of its try, not
+  // a child of it. Declaring them inside the try made every failure path throw
+  // `ReferenceError: quotaKey is not defined` before it could send an error
+  // response — which both swallowed the real error and made refunds impossible.
+  // The catch guards on `quotaKey` being set, so failures before the reservation
+  // simply skip the refund.
+  let quotaKey;
+  let estimatedInputTokens = 0;
+  const quotaWindowSeconds = 60 * 60; // Reset after 1 hour
+  let quotaRefundCap = 0;
   try {
     const modelName = getPrimaryModel();
     const provider = getAIProviderForModel(modelName);
@@ -2466,7 +2477,7 @@ app.post('/api/gemini/generateContent', geminiLimiter, geminiConcurrency, requir
     // (logged-in users on the stable forum userId, anonymous visitors on the client
     // IP so re-doing Turnstile can't reset it). With the feature OFF: the original
     // flat 50/500K cap keyed on the sessionId, identical to the pre-upgrade server.
-    let tier, limits, quotaKey;
+    let tier, limits;
     if (WF_SSO_ENABLED) {
       tier = req.tier || 'anon';
       limits = tierLimits(tier);
@@ -2476,8 +2487,7 @@ app.post('/api/gemini/generateContent', geminiLimiter, geminiConcurrency, requir
       limits = { requests: REQUEST_LIMIT_PER_SESSION, tokens: TOKEN_LIMIT_PER_SESSION };
       quotaKey = sessionId;
     }
-    const quotaWindowSeconds = 60 * 60; // Reset after 1 hour
-    const quotaRefundCap = refundCapFor(limits.requests);
+    quotaRefundCap = refundCapFor(limits.requests);
 
     const validation = validateAnalysisPrompt(contents);
     if (!validation.valid) {
@@ -2504,7 +2514,7 @@ app.post('/api/gemini/generateContent', geminiLimiter, geminiConcurrency, requir
 
     // Estimate tokens in request (rough estimate: 1 token = 4 characters)
     const requestText = serverPrompt;
-    const estimatedInputTokens = Math.ceil(requestText.length / 4);
+    estimatedInputTokens = Math.ceil(requestText.length / 4);
 
     // Check cache using fileHash only after the session has proven ownership by
     // uploading that exact file — AND only when the hash-keyed entry carries

--- a/server/securityHeaders.js
+++ b/server/securityHeaders.js
@@ -36,7 +36,12 @@ function scriptSources({ inlineScriptSources }) {
   return `'self' ${inlineScriptSources} ${WASM_SOURCE} ${AD_SCRIPT_SOURCES}`;
 }
 
-function cspDirectives(frameAncestors, inlineScriptSources) {
+// `reportOnly` drops directives that browsers refuse to honour in a
+// Content-Security-Policy-Report-Only header. Keeping them there is not merely
+// inert: Chrome logs an "is ignored when delivered in a report-only policy"
+// warning for each one, on every page load, which buries the actual violation
+// reports this staged rollout exists to collect.
+function cspDirectives(frameAncestors, inlineScriptSources, { reportOnly = false } = {}) {
   return [
     "default-src 'self'",
     // *.doubleclick.net + www.googleadservices.com cover Google Ads conversion
@@ -49,11 +54,15 @@ function cspDirectives(frameAncestors, inlineScriptSources) {
     "img-src 'self' data: https: blob:",
     `connect-src ${CONNECT_SOURCES}`,
     "frame-src 'self' https://challenges.cloudflare.com https://*.google https://*.google.com https://*.googletagmanager.com https://*.googlesyndication.com https://*.doubleclick.net https://www.paypal.com",
+    // The app registers /sw.js. Without an explicit worker-src this falls back to
+    // script-src, where the hash-based policy has no source that matches a
+    // same-origin worker script and the registration is reported as a violation.
+    "worker-src 'self'",
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self' https://www.paypal.com",
     `frame-ancestors ${frameAncestors}`,
-    'upgrade-insecure-requests'
+    ...(reportOnly ? [] : ['upgrade-insecure-requests'])
   ].join('; ');
 }
 
@@ -109,17 +118,23 @@ export function createSecurityHeadersMiddleware({
   let inlineScriptSources = null;
   let strictHeaders = null;
   let strictEmbedHeaders = null;
+  // Same policy as strictHeaders/strictEmbedHeaders minus the directives that are
+  // ignored in a report-only header, so staging the rollout stays quiet in the console.
+  let strictReportOnlyHeaders = null;
+  let strictEmbedReportOnlyHeaders = null;
 
-  function strictPolicyFor(variant) {
+  function strictPolicyFor(variant, options) {
     const inline = inlineScriptSources ? inlineScriptSources.join(' ') : LEGACY_INLINE_SOURCES;
     return variant === 'embed'
-      ? cspDirectives(EMBED_FRAME_ANCESTORS, inline)
-      : cspDirectives(DEFAULT_FRAME_ANCESTORS, inline);
+      ? cspDirectives(EMBED_FRAME_ANCESTORS, inline, options)
+      : cspDirectives(DEFAULT_FRAME_ANCESTORS, inline, options);
   }
 
   function recompute() {
     strictHeaders = strictPolicyFor('default');
     strictEmbedHeaders = strictPolicyFor('embed');
+    strictReportOnlyHeaders = strictPolicyFor('default', { reportOnly: true });
+    strictEmbedReportOnlyHeaders = strictPolicyFor('embed', { reportOnly: true });
   }
 
   function headersFor(variant) {
@@ -132,7 +147,7 @@ export function createSecurityHeadersMiddleware({
       // Legacy policy keeps enforcing while the strict policy is staged.
       result.csp = legacy;
       if (inlineScriptSources) {
-        result.cspReportOnly = variant === 'embed' ? strictEmbedHeaders : strictHeaders;
+        result.cspReportOnly = variant === 'embed' ? strictEmbedReportOnlyHeaders : strictReportOnlyHeaders;
       }
     }
     return result;

--- a/tests/aiHandlerScope.test.mjs
+++ b/tests/aiHandlerScope.test.mjs
@@ -1,0 +1,128 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as acorn from 'acorn';
+
+// A `catch` block is a sibling scope of its `try`, not a child of it. Anything the
+// catch reads must therefore be declared in the enclosing function scope. Getting
+// this wrong is silent until the failure path actually runs, and then it throws a
+// ReferenceError *inside the error handler* — which both swallows the original
+// error and skips whatever cleanup the catch existed to perform.
+//
+// This bit production: the /api/gemini/generateContent quota-refund block read
+// quotaKey / estimatedInputTokens / quotaWindowSeconds / quotaRefundCap, all of
+// which were declared inside the try. Every upstream AI failure logged
+// "ReferenceError: quotaKey is not defined" instead of returning its mapped status,
+// and no reservation was ever refunded.
+
+const SERVER = fileURLToPath(new URL('../server.js', import.meta.url));
+
+function walk(node, visit, parent = null) {
+  if (!node || typeof node.type !== 'string') return;
+  visit(node, parent);
+  for (const key of Object.keys(node)) {
+    if (key === 'type' || key === 'loc' || key === 'range') continue;
+    const value = node[key];
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        if (child && typeof child.type === 'string') walk(child, visit, node);
+      }
+    } else if (value && typeof value.type === 'string') {
+      walk(value, visit, node);
+    }
+  }
+}
+
+function boundNames(pattern, out) {
+  if (!pattern) return;
+  switch (pattern.type) {
+    case 'Identifier': out.add(pattern.name); break;
+    case 'ObjectPattern':
+      for (const prop of pattern.properties) {
+        boundNames(prop.type === 'RestElement' ? prop.argument : prop.value, out);
+      }
+      break;
+    case 'ArrayPattern':
+      for (const el of pattern.elements) boundNames(el, out);
+      break;
+    case 'AssignmentPattern': boundNames(pattern.left, out); break;
+    case 'RestElement': boundNames(pattern.argument, out); break;
+    default: break;
+  }
+}
+
+// Identifiers in "read" position — excludes property names, object literal keys,
+// declaration targets, and parameter names.
+function readIdentifiers(root) {
+  const names = new Set();
+  walk(root, (node, parent) => {
+    if (node.type !== 'Identifier' || !parent) return;
+    if (parent.type === 'MemberExpression' && !parent.computed && parent.property === node) return;
+    if (parent.type === 'Property' && !parent.computed && parent.key === node) return;
+    if (parent.type === 'VariableDeclarator' && parent.id === node) return;
+    if (parent.type === 'CatchClause' && parent.param === node) return;
+    names.add(node.name);
+  });
+  return names;
+}
+
+function declaredNames(root) {
+  const names = new Set();
+  walk(root, (node) => {
+    if (node.type === 'VariableDeclarator') boundNames(node.id, names);
+  });
+  return names;
+}
+
+function findRouteHandler(ast, routePath) {
+  let handler = null;
+  walk(ast, (node) => {
+    if (handler || node.type !== 'CallExpression') return;
+    const [first] = node.arguments;
+    if (!first || first.type !== 'Literal' || first.value !== routePath) return;
+    const last = node.arguments[node.arguments.length - 1];
+    if (last && (last.type === 'ArrowFunctionExpression' || last.type === 'FunctionExpression')) {
+      handler = last;
+    }
+  });
+  return handler;
+}
+
+test('generateContent catch block only reads names declared in the handler scope', () => {
+  const ast = acorn.parse(readFileSync(SERVER, 'utf8'), {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  });
+
+  const handler = findRouteHandler(ast, '/api/gemini/generateContent');
+  assert.ok(handler, 'the /api/gemini/generateContent handler must be found');
+
+  const tryStatement = handler.body.body.find(node => node.type === 'TryStatement');
+  assert.ok(tryStatement, 'the handler must wrap its work in a try/catch');
+  assert.ok(tryStatement.handler, 'the try must have a catch clause');
+
+  // Names the catch can legitimately see: everything declared in the handler body
+  // outside the try, plus the handler's own parameters.
+  const handlerScope = new Set();
+  for (const param of handler.params) boundNames(param, handlerScope);
+  for (const statement of handler.body.body) {
+    if (statement.type === 'VariableDeclaration') {
+      for (const declarator of statement.declarations) boundNames(declarator.id, handlerScope);
+    }
+  }
+
+  const declaredInTry = declaredNames(tryStatement.block);
+  const readInCatch = readIdentifiers(tryStatement.handler.body);
+
+  const trapped = [...readInCatch]
+    .filter(name => declaredInTry.has(name) && !handlerScope.has(name))
+    .sort();
+
+  assert.deepEqual(
+    trapped,
+    [],
+    `catch reads ${trapped.join(', ')} but they are declared inside the try — ` +
+    'hoist them to the handler scope or they throw ReferenceError on every failure path'
+  );
+});

--- a/tests/securityHeaders.test.mjs
+++ b/tests/securityHeaders.test.mjs
@@ -134,3 +134,33 @@ test('updateInlineScriptHashes rejects malformed source expressions', () => {
   middleware.updateInlineScriptHashes(["'sha256-good='", 'javascript:']);
   assert.equal(middleware.hasInlineScriptHashes(), true, 'valid hashes survive alongside junk');
 });
+
+test('report-only policy omits directives browsers ignore in report-only mode', async () => {
+  const middleware = createSecurityHeadersMiddleware({ cspMode: 'report-only' });
+  middleware.updateInlineScriptHashes(["'sha256-abc='"]);
+  const server = await listenCompat(buildApp(middleware));
+  try {
+    const response = await fetch(`http://127.0.0.1:${server.port}/about`, { headers: { connection: 'close' } });
+    const csp = response.headers.get('content-security-policy');
+    const reportOnly = response.headers.get('content-security-policy-report-only');
+    // Chrome warns once per page load for every ignored directive, drowning the
+    // violation reports the staged rollout is meant to surface.
+    assert.doesNotMatch(reportOnly, /upgrade-insecure-requests/);
+    // The enforcing policy still upgrades — only the report-only copy drops it.
+    assert.match(csp, /upgrade-insecure-requests/);
+  } finally {
+    await server.close();
+  }
+});
+
+test('worker-src is declared so the service worker is not judged by script-src', async () => {
+  const middleware = createSecurityHeadersMiddleware({ cspMode: 'enforce' });
+  middleware.updateInlineScriptHashes(["'sha256-abc='"]);
+  const server = await listenCompat(buildApp(middleware));
+  try {
+    const response = await fetch(`http://127.0.0.1:${server.port}/about`, { headers: { connection: 'close' } });
+    assert.match(response.headers.get('content-security-policy'), /worker-src 'self'/);
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
## The bug

`ReferenceError: quotaKey is not defined` — **17 occurrences in production** since the hardening deploy, still firing as of 19:47 UTC.

The quota refund block added in e195686 lives in the `catch` of `/api/gemini/generateContent`, but `quotaKey`, `estimatedInputTokens`, `quotaWindowSeconds` and `quotaRefundCap` were declared inside the `try`. A `catch` is a **sibling** scope of its `try`, not a child — so all four were out of scope at the point the catch read them.

Two live consequences:

1. **Every AI failure threw a second error inside the error handler**, before it could send its mapped status (502/503/504). The original error was swallowed and the client got a generic failure.
2. **The refund never ran** — so provider outages burned tier quota, exactly the behaviour e195686 was written to prevent.

## The fix

Declarations move to handler scope. The `if (quotaKey && ...)` guard is unchanged, so failures occurring before the reservation still correctly skip the refund.

## Regression test

`tests/aiHandlerScope.test.mjs` parses `server.js` with acorn and asserts the catch reads nothing declared inside the try. Run against the currently deployed revision it fails, naming all four variables:

```
catch reads estimatedInputTokens, quotaKey, quotaRefundCap, quotaWindowSeconds
but they are declared inside the try
```

Every other `try`/`catch` in `server.js`, `server/` and `shared/` was scanned for the same shape — this was the only occurrence.

## CSP noise (how this surfaced)

- `upgrade-insecure-requests` is ignored in a report-only header, and Chrome logs a warning **per page load** for it — that noise was burying the violation reports the staged rollout exists to collect. It now ships only on the enforcing policy.
- Declared `worker-src 'self'` so registering `/sw.js` isn't judged against `script-src`, where the hash policy has no matching source.

## ⚠️ Rollout note

`CSP_MODE=enforce` is **still not safe**. Cloudflare injects `window.__CF$cv$params` inline with a per-request token, so its hash can never be in the set, and the `onload="this.media='all'"` handlers on the CSS links can't be covered by hashes at all.

## Verification

- 187/187 tests pass (+3 added), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)