### PR TITLE
Fix CSP: wasm-unsafe-eval lost its quotes, breaking WASM and the WinDBG upload path

### DIFF
--- a/server/securityHeaders.js
+++ b/server/securityHeaders.js
@@ -28,7 +28,12 @@ const CONNECT_SOURCES =
 
 // 'wasm-unsafe-eval' is required: the client bundle hashes uploads with
 // xxhash-wasm and cannot run without WebAssembly.
-const WASM_SOURCE = 'wasm-unsafe-eval';
+// The single quotes are part of the CSP token, not JS string syntax. Without them
+// the browser parses `wasm-unsafe-eval` as a *host* source expression (a hostname),
+// silently grants nothing, and every WebAssembly.instantiate() throws a CompileError
+// — which took out the WinDBG upload path, since the client hashes the dump with
+// xxhash-wasm before uploading it.
+const WASM_SOURCE = "'wasm-unsafe-eval'";
 
 function scriptSources({ inlineScriptSources }) {
   // `inlineScriptSources` is either "'unsafe-inline'" or a list of

--- a/tests/securityHeaders.test.mjs
+++ b/tests/securityHeaders.test.mjs
@@ -164,3 +164,54 @@ test('worker-src is declared so the service worker is not judged by script-src',
     await server.close();
   }
 });
+
+// CSP keyword source expressions are only keywords when single-quoted. Unquoted,
+// the parser treats them as host source expressions (i.e. a hostname), which
+// grants nothing and fails silently — no header error, no console warning, just a
+// capability that is quietly absent. That is how `wasm-unsafe-eval` shipped
+// unquoted and broke every WebAssembly.instantiate() on the site.
+const CSP_KEYWORDS = [
+  'self', 'none', 'unsafe-inline', 'unsafe-eval', 'wasm-unsafe-eval',
+  'unsafe-hashes', 'strict-dynamic', 'report-sample'
+];
+
+test('every CSP keyword source expression is single-quoted', async () => {
+  const middleware = createSecurityHeadersMiddleware({ cspMode: 'report-only' });
+  middleware.updateInlineScriptHashes(["'sha256-abc='"]);
+  const server = await listenCompat(buildApp(middleware));
+  try {
+    const response = await fetch(`http://127.0.0.1:${server.port}/about`, { headers: { connection: 'close' } });
+    const policies = [
+      response.headers.get('content-security-policy'),
+      response.headers.get('content-security-policy-report-only')
+    ].filter(Boolean);
+    assert.ok(policies.length === 2, 'both policies should be present in report-only mode');
+
+    for (const policy of policies) {
+      for (const directive of policy.split(';')) {
+        const [name, ...tokens] = directive.trim().split(/\s+/);
+        if (!name) continue;
+        for (const token of tokens) {
+          if (CSP_KEYWORDS.includes(token)) {
+            assert.fail(`${name} contains bare "${token}" — CSP keywords must be written as '${token}'`);
+          }
+        }
+      }
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+test('wasm stays enabled for xxhash-wasm, quoted so the browser honours it', async () => {
+  const middleware = createSecurityHeadersMiddleware({ cspMode: 'report-only' });
+  middleware.updateInlineScriptHashes(["'sha256-abc='"]);
+  const server = await listenCompat(buildApp(middleware));
+  try {
+    const response = await fetch(`http://127.0.0.1:${server.port}/about`, { headers: { connection: 'close' } });
+    // The enforcing policy is the one that can actually break the client.
+    assert.match(response.headers.get('content-security-policy'), /script-src[^;]*'wasm-unsafe-eval'/);
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
## Cause of "WinDBG server unavailable"

`13e2e7d` extracted the WASM source into a constant and dropped the single quotes that are **part of the CSP token**:

```diff
-`script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' ${AD_SCRIPT_SOURCES}`
+const WASM_SOURCE = 'wasm-unsafe-eval';   // ← quotes gone
```

The served header became `script-src 'self' 'unsafe-inline' wasm-unsafe-eval …`.

Unquoted, a CSP keyword is parsed as a **host source expression** (a hostname), so it grants nothing. It fails silently — the header is well-formed and nothing warns about the token itself.

## Effect

The client hashes the dump with **xxhash-wasm** before uploading, so `WebAssembly.instantiate()` threw and the WinDBG upload never started:

```
[WinDBG] Error checking cache status: CompileError: WebAssembly.instantiate() ...
[WinDBG] Analysis failed: CompileError ...
[Analyzer] WinDBG analysis failed ...
[Analyzer] Falling back to local analysis...
```

This is also why there were **no server-side WinDBG errors in Cloud Run** — the request was never made.

## Guards added

- Every directive of both policies is scanned for bare CSP keywords (`self`, `none`, `unsafe-inline`, `unsafe-eval`, `wasm-unsafe-eval`, `unsafe-hashes`, `strict-dynamic`, `report-sample`). Re-introducing the bug fails the test by name.
- `'wasm-unsafe-eval'` is pinned in the **enforcing** policy, the one that can actually break the client.

189/189 tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)