### PR TITLE
Coalesce concurrent session init — one page load was burning 8 of the 20-request auth budget

### DIFF
--- a/utils/sessionManager.ts
+++ b/utils/sessionManager.ts
@@ -34,12 +34,35 @@ export function onSessionInvalid(listener: () => void): () => void {
   return () => window.removeEventListener(SESSION_INVALID_EVENT, handler);
 }
 
+// Concurrent callers share one request. Several components initialise the session
+// as they mount (FileUploader, the analyzer's existing-session check, useAnalysis),
+// and every call site passes force=true, which bypasses the `sessionInitialized`
+// guard above. Without coalescing, one page load fired ~8 GET /api/auth/session
+// calls in a few seconds and two or three reloads exhausted the shared auth
+// limiter (20 requests / 10 min), leaving the client stuck on 429 with no session.
+// `force` still bypasses the cached result, but never duplicates a live request.
+let inFlightInit: Promise<boolean> | null = null;
+
 export async function initializeSession(force: boolean = false): Promise<boolean> {
   if (sessionInitialized && !force) {
     console.log('[Session] Already initialized, skipping');
     return true;
   }
 
+  if (inFlightInit) {
+    console.log('[Session] Initialization already in flight, joining it');
+    return inFlightInit;
+  }
+
+  inFlightInit = requestSession();
+  try {
+    return await inFlightInit;
+  } finally {
+    inFlightInit = null;
+  }
+}
+
+async function requestSession(): Promise<boolean> {
   try {
     console.log('[Session] Initializing session...');
     const response = await fetch('/api/auth/session', {


### PR DESCRIPTION
## Symptom

```
api/auth/session:1          Failed to load resource: 429
[Session] Init failed: 429
api/auth/verify-turnstile:1 Failed to load resource: 429
```

The client ends up with **no session at all**, so nothing can be analyzed.

## Cause

Three components initialise the session as they mount — `FileUploader`, the analyzer's existing-session check, and `useAnalysis` — and **every call site passes `force: true`**. That flag bypasses the `sessionInitialized` guard, and there was no in-flight deduplication, so each caller issued its own `GET /api/auth/session`.

Observed in the console: **~8 session requests in ~7 seconds on a single page load.**

`authLimiter` is 20 requests / 10 min and is *shared* with `/api/auth/verify-turnstile`, so two or three reloads exhaust the window.

## Fix

Concurrent callers await one shared promise. `force` still bypasses the cached result — a genuine refresh still re-requests — but can no longer duplicate a request already in flight. A page load now costs one call instead of eight.

Deliberately did **not** raise the rate limit: the limit is reasonable, the request amplification was the defect.

189/189 tests pass, typecheck clean, production build + SRI regenerate cleanly.

> Note: there is no frontend test harness in this repo (all suites are server-side `.mjs`), so this change is covered by typecheck and manual verification rather than a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)