### PR TITLE
Loosen per-IP rate limits and make them env-tunable

### DIFF
--- a/server.js
+++ b/server.js
@@ -1326,12 +1326,45 @@ const apiLimiter = makeLimiter({
   }
 });
 
-const authLimiter = makeLimiter({ windowMs: 10 * 60 * 1000, max: 20, name: 'auth' });
-const cacheLimiter = makeLimiter({ windowMs: 15 * 60 * 1000, max: 120, name: 'cache' });
-const geminiLimiter = makeLimiter({ windowMs: 15 * 60 * 1000, max: 40, name: 'gemini' });
-const windbgUploadLimiter = makeLimiter({ windowMs: 60 * 60 * 1000, max: 20, name: 'windbg-upload' });
-const windbgPollLimiter = makeLimiter({ windowMs: 15 * 60 * 1000, max: 300, name: 'windbg-poll' });
-const archiveLimiter = makeLimiter({ windowMs: 60 * 60 * 1000, max: 10, name: 'archive' });
+// These are per-IP burst guards, not the cost control. Spend is bounded by the
+// per-session quota (REQUEST_LIMIT_PER_SESSION / TOKEN_LIMIT_PER_SESSION and the
+// tier limits), which these deliberately do not duplicate — so they are sized for
+// "a real person using the site briskly" rather than for billing safety. Each is
+// overridable at deploy time for incident response without a code change.
+//
+// auth is the loosest: it guards session creation and Turnstile verification, both
+// cheap and already bot-gated, and it is the one a normal user trips just by
+// reloading the page a few times.
+const authLimiter = makeLimiter({
+  windowMs: 10 * 60 * 1000,
+  max: readPositiveInt(process.env.AUTH_RATE_LIMIT_MAX, 100),
+  name: 'auth'
+});
+const cacheLimiter = makeLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: readPositiveInt(process.env.CACHE_RATE_LIMIT_MAX, 300),
+  name: 'cache'
+});
+const geminiLimiter = makeLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: readPositiveInt(process.env.GEMINI_RATE_LIMIT_MAX, 80),
+  name: 'gemini'
+});
+const windbgUploadLimiter = makeLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: readPositiveInt(process.env.WINDBG_UPLOAD_RATE_LIMIT_MAX, 50),
+  name: 'windbg-upload'
+});
+const windbgPollLimiter = makeLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: readPositiveInt(process.env.WINDBG_POLL_RATE_LIMIT_MAX, 600),
+  name: 'windbg-poll'
+});
+const archiveLimiter = makeLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: readPositiveInt(process.env.ARCHIVE_RATE_LIMIT_MAX, 30),
+  name: 'archive'
+});
 const externalAnalyzeSubmitLimiter = makeLimiter({
   windowMs: 60 * 60 * 1000,
   max: 60,


### PR DESCRIPTION
## Why

The per-IP limiters were tight enough that ordinary use tripped them. Most visibly `auth` at **20 / 10 min**, *shared* between `/api/auth/session` and `/api/auth/verify-turnstile` — a user could exhaust it just by reloading the analyzer a few times and end up with **no session at all**:

```
api/auth/session:1  Failed to load resource: 429
[Session] Init failed: 429
```

(PR #86 removed the request amplification that made this trivial to hit; this widens the headroom on top of that.)

## Changes

| Limiter | Before | After |
|---|---|---|
| `auth` | 20 / 10 min | **100 / 10 min** |
| `cache` | 120 / 15 min | 300 / 15 min |
| `gemini` | 40 / 15 min | 80 / 15 min |
| `windbg-upload` | 20 / hour | 50 / hour |
| `windbg-poll` | 300 / 15 min | 600 / 15 min |
| `archive` | 10 / hour | 30 / hour |

Each is now overridable at deploy time — `AUTH_RATE_LIMIT_MAX`, `CACHE_RATE_LIMIT_MAX`, `GEMINI_RATE_LIMIT_MAX`, `WINDBG_UPLOAD_RATE_LIMIT_MAX`, `WINDBG_POLL_RATE_LIMIT_MAX`, `ARCHIVE_RATE_LIMIT_MAX` — so a limit can be tightened during an incident without a code change.

## What this does not change

These are **burst guards, not the cost control**. Spend stays bounded by the per-session quota (`REQUEST_LIMIT_PER_SESSION` = 50, `TOKEN_LIMIT_PER_SESSION` = 500K, plus the tier limits), which is untouched. The global `api` limiter (500 / 15 min) is also unchanged.

189/189 tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)