### PR TITLE
Give the DeepSeek reasoning trace room in the output budget

### DIFF
--- a/server.js
+++ b/server.js
@@ -191,8 +191,17 @@ const HASH_RE = /^[a-f0-9]{8,16}$/i;
 const EXTERNAL_JOB_UID_RE = /^API-\d{10,17}-[a-f0-9]{12}$/i;
 const TURNSTILE_ACTION = process.env.TURNSTILE_ACTION || 'file-upload';
 const AI_MAX_PROMPT_CHARS = readPositiveInt(process.env.AI_MAX_PROMPT_CHARS, 250_000);
+// Output budget for an analysis response. On a reasoning model the reasoning trace
+// is charged against the same budget as the answer, so a cap sized for the JSON
+// alone gets consumed by the reasoning and the object is cut off mid-string —
+// surfacing as finishReason "LENGTH" and "AI response was not valid JSON". This is
+// a ceiling, not a target: a model that finishes early is billed for what it used.
+const AI_MAX_OUTPUT_TOKENS = readPositiveInt(process.env.AI_MAX_OUTPUT_TOKENS, 16_384);
 const GEMINI_TIMEOUT_MS = readPositiveInt(process.env.GEMINI_TIMEOUT_MS, 60_000);
-const DEEPSEEK_TIMEOUT_MS = readPositiveInt(process.env.DEEPSEEK_TIMEOUT_MS, GEMINI_TIMEOUT_MS);
+// DeepSeek runs with a reasoning trace, so it is materially slower than a
+// straight completion and gets its own budget rather than inheriting Gemini's.
+// Cloud Run's request timeout (300s by default) is the real ceiling.
+const DEEPSEEK_TIMEOUT_MS = readPositiveInt(process.env.DEEPSEEK_TIMEOUT_MS, 120_000);
 const DEEPSEEK_API_BASE_URL = process.env.DEEPSEEK_API_BASE_URL || DEFAULT_DEEPSEEK_API_BASE_URL;
 // OpenRouter free-tier failover: used when the DeepSeek account cannot serve
 // requests (out of credits, auth revoked). Unset key = failover disabled.
@@ -208,7 +217,14 @@ const OPENAI_FREE_MODEL = process.env.OPENAI_FREE_MODEL || DEFAULT_OPENAI_FREE_M
 const OPENAI_BASE_URL = process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
 const OPENAI_FREE_DAILY_TOKEN_CAP = readPositiveInt(process.env.OPENAI_FREE_DAILY_TOKEN_CAP, 10_000_000);
 const OPENAI_FREE_SAFETY_BUFFER = readPositiveInt(process.env.OPENAI_FREE_SAFETY_BUFFER, 250_000);
-const DEEPSEEK_REASONING_EFFORT = process.env.DEEPSEEK_REASONING_EFFORT === 'max' ? 'max' : 'high';
+// Effort below 'high' is selectable now, but the default is unchanged: the vendor's
+// accepted values are not verified here beyond 'high'/'max', which is all this code
+// has ever sent, so a lower setting is opt-in and instantly revertible via env
+// rather than something a deploy silently changes underneath the analysis quality.
+const DEEPSEEK_REASONING_EFFORTS = ['minimal', 'low', 'medium', 'high', 'max'];
+const DEEPSEEK_REASONING_EFFORT = DEEPSEEK_REASONING_EFFORTS.includes(process.env.DEEPSEEK_REASONING_EFFORT)
+  ? process.env.DEEPSEEK_REASONING_EFFORT
+  : 'high';
 const DEEPSEEK_THINKING_ENABLED = !['0', 'false', 'disabled'].includes(
   String(process.env.DEEPSEEK_THINKING || 'enabled').toLowerCase()
 );
@@ -1110,7 +1126,7 @@ async function generateAIContent(request) {
     // normal chain when the daily quota is out or the attempt fails.
     const configuredMaxOutput = Number(request.config?.maxOutputTokens);
     const projectedTokens = Math.ceil(String(request.contents || '').length / 4)
-      + (Number.isFinite(configuredMaxOutput) ? configuredMaxOutput : 4096);
+      + (Number.isFinite(configuredMaxOutput) ? configuredMaxOutput : AI_MAX_OUTPUT_TOKENS);
     if (await openAIFreeGate(projectedTokens)) {
       try {
         const response = await withTimeout(
@@ -2674,11 +2690,11 @@ app.post('/api/gemini/generateContent', geminiLimiter, geminiConcurrency, requir
       responseMimeType: 'application/json',
       candidateCount: 1,
       temperature: 0.5,
-      maxOutputTokens: 4096,
+      maxOutputTokens: AI_MAX_OUTPUT_TOKENS,
       responseSchema: SERVER_REPORT_RESPONSE_SCHEMA
     };
     if (Number.isFinite(frontendConfig.maxOutputTokens)) {
-      sdkConfig.maxOutputTokens = Math.min(Math.max(Math.floor(frontendConfig.maxOutputTokens), 256), 4096);
+      sdkConfig.maxOutputTokens = Math.min(Math.max(Math.floor(frontendConfig.maxOutputTokens), 256), AI_MAX_OUTPUT_TOKENS);
     }
     if (Number.isFinite(frontendConfig.temperature)) {
       sdkConfig.temperature = Math.min(Math.max(frontendConfig.temperature, 0), 1);
@@ -3578,7 +3594,7 @@ ${analysisForPrompt}
       config: {
         responseMimeType: 'application/json',
         temperature: 0.5,
-        maxOutputTokens: 4096,
+        maxOutputTokens: AI_MAX_OUTPUT_TOKENS,
         systemInstruction: SYSTEM_INSTRUCTION_ANALYSIS
       }
     });

--- a/services/aiProvider.js
+++ b/services/aiProvider.js
@@ -3,6 +3,10 @@ export const DEEPSEEK_V4_FLASH_MODEL = 'deepseek-v4-flash';
 export const DEFAULT_DEEPSEEK_API_BASE_URL = 'https://api.deepseek.com';
 
 const TRANSIENT_DEEPSEEK_STATUSES = new Set([429, 500, 503]);
+// Reasoning effort levels this client is willing to send. 'high' and 'max' are the
+// values it has always used; the lower levels exist so an operator can trade depth
+// for latency when reasoning is overrunning the request timeout.
+const DEEPSEEK_REASONING_EFFORTS = new Set(['minimal', 'low', 'medium', 'high', 'max']);
 
 export class AIProviderError extends Error {
   constructor(message, { code = 'AI_PROVIDER_ERROR', status = 502, retryable = false } = {}) {
@@ -155,7 +159,9 @@ export async function generateDeepSeekContent(request, {
   messages.push({ role: 'user', content: prompt });
 
   const enabled = thinkingEnabled !== false;
-  const effort = reasoningEffort === 'max' ? 'max' : 'high';
+  // Anything outside the known set collapses to 'high' — the long-standing default —
+  // so an unrecognised value can never reach the provider as an invalid argument.
+  const effort = DEEPSEEK_REASONING_EFFORTS.has(reasoningEffort) ? reasoningEffort : 'high';
   const body = {
     model: DEEPSEEK_V4_FLASH_MODEL,
     messages,

--- a/tests/aiProvider.test.mjs
+++ b/tests/aiProvider.test.mjs
@@ -322,3 +322,47 @@ test('isOpenAIFreeTier recognizes the live complimentary tier string', () => {
   assert.equal(isOpenAIFreeTier('flex'), false);
   assert.equal(isOpenAIFreeTier(undefined), false);
 });
+
+// Reasoning effort is selectable below 'high' so an operator can trade depth for
+// latency when the reasoning trace is overrunning the request timeout. Unknown
+// values must never reach the provider as an invalid argument.
+async function deepSeekEffortRequest(reasoningEffort) {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    calls.push({ url, options });
+    return new Response(JSON.stringify({
+      model: DEEPSEEK_V4_FLASH_MODEL,
+      choices: [{ finish_reason: 'stop', message: { content: '{"summary":"ok"}' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+
+  await generateDeepSeekContent({
+    model: DEEPSEEK_V4_FLASH_MODEL,
+    contents: 'Analyze this dump and return JSON.',
+    config: { responseMimeType: 'application/json', maxOutputTokens: 16384 }
+  }, { apiKey: 'test-key', fetchImpl, maxRetries: 0, reasoningEffort });
+
+  return JSON.parse(calls[0].options.body);
+}
+
+test('DeepSeek reasoning effort accepts levels below high', async () => {
+  for (const effort of ['minimal', 'low', 'medium', 'high', 'max']) {
+    const body = await deepSeekEffortRequest(effort);
+    assert.equal(body.reasoning_effort, effort, `${effort} should pass through`);
+  }
+});
+
+test('DeepSeek reasoning effort falls back to high for unrecognised values', async () => {
+  for (const effort of ['turbo', '', null, undefined, 'HIGH']) {
+    const body = await deepSeekEffortRequest(effort);
+    assert.equal(body.reasoning_effort, 'high', `${String(effort)} should collapse to high`);
+  }
+});
+
+test('DeepSeek max_tokens carries the configured output budget', async () => {
+  const body = await deepSeekEffortRequest('high');
+  // The budget must cover reasoning + answer; too small truncates the JSON
+  // mid-object and surfaces as finish_reason "LENGTH".
+  assert.equal(body.max_tokens, 16384);
+});


### PR DESCRIPTION
## Symptom

Two failure modes in production, from one cause:

```
ai.error            | DeepSeek request timed out
ai.response.invalid | finishReason: "LENGTH", deepseek-v4-flash
                    | responsePreview: {"summary": "MEMORY_MANAGEMENT (0x1A) crash occurred insi…
```

The preview is cut off mid-string — the model never got to close the JSON object.

## Cause

The model runs `thinking: enabled` at `reasoning_effort: 'high'`. **On a reasoning model the reasoning trace is charged against the same `max_tokens` budget as the answer.** That budget was `4096`, hard-clamped at `server.js:2697`, so reasoning consumed it before the answer finished.

The same high-effort reasoning over a ~14K-token prompt also routinely overran the 60s timeout — which DeepSeek *inherited from Gemini* (`DEEPSEEK_TIMEOUT_MS` defaulted to `GEMINI_TIMEOUT_MS`) despite being far slower.

## Changes

- **`AI_MAX_OUTPUT_TOKENS`** (default `16384`, env-tunable) replaces the `4096` literal at all three call sites and becomes the clamp ceiling. A ceiling, not a target — a model that finishes early is billed for what it used.
- **`DEEPSEEK_TIMEOUT_MS`** gets its own **120s** default rather than inheriting Gemini's 60s. Cloud Run's 300s request timeout is the real ceiling, and the client sets no deadline of its own.
- **`reasoning_effort`** accepts `minimal|low|medium|high|max` instead of collapsing everything to `'high'`.

## On the effort default

Deliberately **unchanged** at `'high'`. Only `'high'` and `'max'` have ever been sent to this vendor and I did not verify the lower values against their API, so a lower level is opt-in via `DEEPSEEK_REASONING_EFFORT` and instantly revertible. Any unrecognised value still collapses to `'high'` rather than reaching the provider as an invalid argument.

The budget fix is the one that addresses the confirmed `LENGTH` truncation, and it applies by default.

192/192 tests pass (+3), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)