### PR TITLE
Collapse the header nav into the hamburger below 1025px

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -38,6 +38,22 @@ const Navigation: React.FC = () => {
     useEffect(() => {
         closeMobileMenu();
     }, [location.pathname]);
+
+    // Close the menu when the viewport grows past the nav collapse threshold.
+    // The stylesheet hides the overlay above it, but isMobileMenuOpen would stay
+    // true and keep the `mobile-menu-open` scroll lock on <body> — leaving the page
+    // unscrollable with no visible menu to dismiss. Threshold matches styles.css.
+    useEffect(() => {
+        const desktop = window.matchMedia('(min-width: 1025px)');
+        const syncToViewport = () => {
+            if (desktop.matches) {
+                setIsMobileMenuOpen(false);
+            }
+        };
+        syncToViewport();
+        desktop.addEventListener('change', syncToViewport);
+        return () => desktop.removeEventListener('change', syncToViewport);
+    }, []);
     
     return (
         <>

--- a/styles.css
+++ b/styles.css
@@ -2590,9 +2590,6 @@ body.mobile-menu-open {
   .logo-icon { width: 1.75rem; height: 1.75rem; flex-shrink: 0; }
   .logo-text { font-size: 0.9rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .logo-subtitle { display: none; }
-  .desktop-nav { display: none; }
-  .mobile-menu-toggle { display: flex; }
-  .mobile-nav { display: block; }
   .hero { padding: 2rem 0; min-height: 70vh; }
   .hero-title { font-size: clamp(1.75rem, 8vw, 2.5rem); line-height: 1.1; }
   .hero-subtitle { font-size: 0.9rem; margin-bottom: 2rem; }
@@ -2682,9 +2679,6 @@ body.mobile-menu-open {
     max-width: 100%;
     box-sizing: border-box;
   }
-  .desktop-nav { display: none; }
-  .mobile-menu-toggle { display: flex; }
-  .mobile-nav { display: block; }
   .hero { padding: 2.5rem 0; min-height: 75vh; }
   .hero-actions { flex-direction: column; gap: 1rem; }
   .btn-large { width: auto; min-width: 200px; }
@@ -2714,10 +2708,27 @@ body.mobile-menu-open {
   .footer-content { grid-template-columns: 1fr 1fr; text-align: left; gap: 2rem; }
 }
 
-@media (min-width: 769px) {
+/* Navigation collapse threshold.
+   Deliberately its own breakpoint rather than reusing the 768px page-layout one.
+   The bar holds seven links (Home, Analyzer, About, Documentation, Stats, Forum,
+   Donate) alongside the logo, theme toggle and account widget, which needs roughly
+   960px before the links stop crowding each other. A browser docked to half of a
+   1080p/1440p screen lands around 760-960px — wide enough to clear 768px, so the
+   full bar rendered with no room for it. Collapsing to the hamburger up to 1024px
+   keeps the links legible at every width. */
+@media (max-width: 1024px) {
+  .desktop-nav { display: none; }
+  .mobile-menu-toggle { display: flex; }
+}
+
+@media (min-width: 1025px) {
   .desktop-nav { display: flex; gap: 1.5rem; }
   .mobile-menu-toggle { display: none; }
-  .mobile-nav { display: none; }
+  /* .open is also matched: `.mobile-nav.open` (0,2,0) outranks a bare
+     `.mobile-nav` (0,1,0), so without it an open menu survives a resize
+     to desktop width and leaves the overlay covering the page. */
+  .mobile-nav,
+  .mobile-nav.open { display: none; }
 }
 
 /* Spacing utilities */


### PR DESCRIPTION
## Problem

Adding **Stats** brought the header to seven links — Home, Analyzer, About, Documentation, Stats, Forum, Donate — alongside the logo, theme toggle and account widget.

Measured in a browser, the link row alone is **728px wide**, so the bar needs roughly 960px before items stop crowding.

The collapse threshold was **768px**, borrowed from the page-layout breakpoints. A browser docked to half a 1080p/1440p screen lands around **760–960px** — wide enough to clear 768px, so the full bar rendered into a space that couldn't hold it.

## Changes

- Nav switch moves to **its own breakpoint at 1024/1025px**, no longer tied to the layout breakpoints. The duplicated copies inside the `480px` and `481–768px` blocks are removed, so there's one source of truth.
- The desktop rule now also matches `.mobile-nav.open` — `.mobile-nav.open` (0,2,0) outranks a bare `.mobile-nav` (0,1,0), so the old rule **could not hide an already-open menu**.
- `Navigation` closes the menu when the viewport crosses the threshold. The CSS hides the overlay, but `isMobileMenuOpen` stayed true and kept the `mobile-menu-open` scroll lock on `<body>` — leaving the page **unscrollable with no visible menu to dismiss**. Raising the threshold made that much easier to hit.

## Verified in a real browser against the production build

| Viewport | Desktop nav | Hamburger | Notes |
|---|---|---|---|
| 900px | `none` | `flex` | no horizontal scroll |
| 1024px | `none` | `flex` | boundary |
| 1025px | `flex` | `none` | 728px wide, **0px overflow** |

Open the menu at 900px then resize to 1280px → scroll lock released, overlay hidden, desktop nav restored, page scrollable.

192/192 tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)